### PR TITLE
Fixes compilation error by adding -Wno-strict-prototypes option

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 if (MSVC)
     add_compile_options(/W4 /WX)
 else()
-    add_compile_options(-Wall -Wextra -pedantic -Werror -fPIC)
+    add_compile_options(-Wall -Wextra -pedantic -Werror -fPIC -Wno-strict-prototypes)
 endif()
 
 if (ON_WINDOWS)


### PR DESCRIPTION
When compiling for M1, I always get this error:

```
seabolt/src/seabolt/src/bolt/mem.h:104:34: error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]
int64_t BoltMem_allocation_events();
```

The way to avoid this is to not throw the error for this warning and this PR adds that option to the /src/CMakeLists.txt

After that, compilation succeeded.